### PR TITLE
Initial cleanup, and add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+name = "tahmo-api"
+version = "2.0.0"
+description = "A Python library for interacting with the TAHMO API"
+
+dependencies = [
+	"numpy",
+	"pandas",
+	"python-dateutil",
+	"requests",
+]


### PR DESCRIPTION
* Disable the `gc.collect()` calls, unless `manualMemoryCleanup=True` is passed.
* Update some Pandas indexing to explicitly use `loc`, avoiding a deprecation warning.
* Remove an unnecessary duplicate `serie` in combining shortcodes.
* Add a `pyproject.toml`, so the package is pip installable.